### PR TITLE
feat: reset task in error state where resume task

### DIFF
--- a/entity/src/common.rs
+++ b/entity/src/common.rs
@@ -1,7 +1,6 @@
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use sea_orm::entity::prelude::*;
 use serde_repr::*;
-
 /// Used to indicate the state of the current task, the inner type is i32
 /// 0 Undefined old state
 /// 1 Init every new task should be init
@@ -24,6 +23,7 @@ use serde_repr::*;
 )]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]
 pub enum TaskState {
+    //todo try to implement to_string
     #[sea_orm(num_value = 0)]
     Undefined = 0,
     #[sea_orm(num_value = 1)]

--- a/gpuproxy/src/cli/params_fetch_cli.rs
+++ b/gpuproxy/src/cli/params_fetch_cli.rs
@@ -1,6 +1,6 @@
 use crate::cli::params_fetch;
 use anyhow::{anyhow, Result};
-use clap::{Arg, ArgAction, ArgMatches, Command, value_parser};
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 
 pub async fn fetch_params_cmds<'a>() -> Command<'a> {
     Command::new("paramfetch")

--- a/gpuproxy/src/cli/tasks.rs
+++ b/gpuproxy/src/cli/tasks.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 
 use crate::proxy_rpc::rpc::{get_proxy_api, GpuServiceRpcClient};
 use chrono::{DateTime, Local, LocalResult, NaiveDateTime, TimeZone, Utc};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use entity::tasks::Model as Task;
 use entity::{TaskState, TaskType};
 use tabled::{builder::Builder, Style};
@@ -32,18 +32,18 @@ pub async fn list_task_cmds<'a>() -> Command<'a> {
             Command::new("update-state")
                 .about("update status of task")
                 .args(&[
-                    Arg::new("id")
-                        .long("id")
-                        .multiple_values(true)
-                        .takes_value(true)
-                        .required(true)
-                        .help("id slice of id"),
                     Arg::new("state")
                         .long("state")
                         .required(true)
                         .takes_value(true)
                         .value_parser(value_parser!(i32))
                         .help("Init = 1\nRunning = 2\nError = 3\nCompleted = 4"),
+                    Arg::new("id")
+                        .last(true)
+                        .multiple_values(true)
+                        .takes_value(true)
+                        .required(true)
+                        .help("id slice of id"),
                 ]),
         )
 }
@@ -122,7 +122,7 @@ fn print_task(tasks: Vec<Task>) -> Result<()> {
             task.id.as_str(),
             task.miner.as_str(),
             task.task_type.to_string().as_str(),
-            task.state.to_string().as_str(),
+            state_to_string(task.state).as_str(),
             task.resource_id.as_str(),
             task.error_msg.as_str(),
             unit_time(task.create_at).as_str(),
@@ -141,5 +141,15 @@ fn unit_time(tm: i64) -> String {
         LocalResult::None => "".to_string(),
         LocalResult::Single(v) => v.to_string(),
         LocalResult::Ambiguous(v1, v2) => format!("{}, {}", v1, v2),
+    }
+}
+
+fn state_to_string(state: TaskState) -> String {
+    match state {
+        TaskState::Undefined => "Undefined".to_string(),
+        TaskState::Init => "Init".to_string(),
+        TaskState::Running => "Running".to_string(),
+        TaskState::Error => "Error".to_string(),
+        TaskState::Completed => "Completed".to_string(),
     }
 }

--- a/gpuproxy/src/gpuproxy/main.rs
+++ b/gpuproxy/src/gpuproxy/main.rs
@@ -86,8 +86,7 @@ async fn main() {
                         .long("debug-sql")
                         .env("C2PROXY_DEBUG_SQL")
                         .required(false)
-                        .takes_value(false)
-                        .action(ArgAction::SetFalse)
+                        .action(ArgAction::SetTrue)
                         .help("print sql to debug"),
                 ])
                 .args(worker_args),
@@ -103,7 +102,9 @@ async fn main() {
         _ => Ok(()), // Either no subcommand or one not tested for...
     };
 
-    println!("{:?}", exec_result);
+    if let Err(e) = exec_result {
+        println!("{:?}", e);
+    }
 }
 
 async fn start_server(sub_m: &&ArgMatches) -> Result<()> {

--- a/gpuproxy/src/gpuproxy_worker/main.rs
+++ b/gpuproxy/src/gpuproxy_worker/main.rs
@@ -72,9 +72,8 @@ async fn main() {
                         .long("debug-sql")
                         .env("C2PROXY_DEBUG_SQL")
                         .required(false)
-                        .takes_value(false)
-                        .action(ArgAction::SetFalse)
-                        .help("print sql to debug issue"),
+                        .action(ArgAction::SetTrue)
+                        .help("print sql to debug"),
                 ])
                 .args(worker_args),
         )

--- a/gpuproxy/src/proxy_rpc/db_ops.rs
+++ b/gpuproxy/src/proxy_rpc/db_ops.rs
@@ -189,6 +189,7 @@ impl WorkerFetch for DbOpsImpl {
             .col_expr(Tasks::Column::State, Expr::value(TaskState::Completed))
             .col_expr(Tasks::Column::WorkerId, Expr::value(worker_id_arg.clone()))
             .col_expr(Tasks::Column::Proof, Expr::value(proof_str))
+            .col_expr(Tasks::Column::ErrorMsg, Expr::value(""))
             .col_expr(
                 Tasks::Column::CompleteAt,
                 Expr::value(Utc::now().timestamp()),

--- a/gpuproxy/src/proxy_rpc/worker.rs
+++ b/gpuproxy/src/proxy_rpc/worker.rs
@@ -196,7 +196,6 @@ async fn c2(resource: Vec<u8>) -> anyhow::Result<SealCommitPhase2Output> {
     let join_result = tokio::task::spawn_blocking(move || {
         let c2_resource: C2Resource =
             serde_json::from_slice(&resource).context("deserialize c2 resource")?;
-
         info!(
             "start to do c2 task. size: {}",
             u64::from(c2_resource.c1out.registered_proof.sector_size())


### PR DESCRIPTION
1.  更新证明字段时，重置errormsg
2. 插件重入任务时，如果任务处于错误状态，自动重置任务
3. 优化日志
4. 修改了update-state命令
```
gpuproxy tasks update-state --state 1 -- 3bd04d17-9092-5aa1-b456-e626dd1d7989
```
5. 修复了debug-sql flag的错误