### PR TITLE
feat/use rpc as default of resource type for gpuproxy worker

### DIFF
--- a/gpuproxy/src/config/mod.rs
+++ b/gpuproxy/src/config/mod.rs
@@ -5,7 +5,8 @@ use entity::TaskType;
 /// and the second is file resource that save task parameters in file system
 #[derive(Clone, Debug)]
 pub enum Resource {
-    Db,
+    RPC,
+    DB,
     FS(String),
 }
 
@@ -36,10 +37,10 @@ impl ServiceConfig {
         allow_types: Option<Vec<TaskType>>,
         debug_sql: bool,
     ) -> Self {
-        let resource = if resource_type == "db" {
-            Resource::Db
-        } else {
-            Resource::FS(resource_path)
+        let resource = match resource_type.as_str() {
+            "db" => Resource::DB,
+            "rpc" => Resource::RPC,
+            _ => Resource::FS(resource_path),
         };
 
         Self {
@@ -82,11 +83,12 @@ impl WorkerConfig {
         debug_sql: bool,
         manual_ip: Option<String>,
     ) -> Self {
-        let resource = if resource_type == "db" {
-            Resource::Db
-        } else {
-            Resource::FS(resource_path)
+        let resource = match resource_type.as_str() {
+            "db" => Resource::DB,
+            "rpc" => Resource::RPC,
+            _ => Resource::FS(resource_path),
         };
+
         WorkerConfig {
             url,
             db_dsn,

--- a/gpuproxy/src/gpuproxy/main.rs
+++ b/gpuproxy/src/gpuproxy/main.rs
@@ -30,7 +30,7 @@ async fn main() {
     let fetch_params_cmds = cli::fetch_params_cmds().await;
     let worker_cmds = cli::worker_cmds().await;
     let app_m = Command::new("gpuproxy")
-        .version("0.0.1")
+        .version("0.0.2")
         .args(&[
             Arg::new("url")
                 .long("url")

--- a/gpuproxy/src/gpuproxy/main.rs
+++ b/gpuproxy/src/gpuproxy/main.rs
@@ -192,8 +192,9 @@ async fn start_server(sub_m: &&ArgMatches) -> Result<()> {
     let arc_pool = Arc::new(db_ops);
 
     let resource: Arc<dyn resource::ResourceOp + Send + Sync> = match cfg.resource {
-        Resource::Db => Arc::new(resource::DbResource::new(arc_pool.clone())),
+        Resource::DB => Arc::new(resource::DbResource::new(arc_pool.clone())),
         Resource::FS(path) => Arc::new(resource::FileResource::new(path)),
+        Resource::RPC => return Err(anyhow!("RPC resource type is not support in server")),
     };
 
     let rpc_module = rpc::register(resource.clone(), arc_pool);

--- a/gpuproxy/src/gpuproxy_worker/main.rs
+++ b/gpuproxy/src/gpuproxy_worker/main.rs
@@ -25,7 +25,6 @@ const GPUPROXY_WORKER_ABOUT: &str = "gpuproxy worker [supra c2 enabled]";
 #[cfg(not(feature = "supra-c2"))]
 const GPUPROXY_WORKER_ABOUT: &str = "gpuproxy worker";
 
-
 #[tokio::main]
 async fn main() {
     let worker_args = cli::get_worker_arg();
@@ -60,10 +59,8 @@ async fn main() {
                     Arg::new("resource-type")
                         .long("resource-type")
                         .env("C2PROXY_RESOURCE_TYPE")
-                        .default_value("fs")
-                        .help(
-                            "resource type(db(only for test, have bug for executing too long sql), fs)",
-                        ),
+                        .default_value("rpc")
+                        .help("resource type( fs,rpc(default))"),
                     Arg::new("fs-resource-path")
                         .long("fs-resource-path")
                         .env("C2PROXY_FS_RESOURCE_PATH")
@@ -176,8 +173,9 @@ async fn run_worker(sub_m: &&ArgMatches) -> Result<()> {
 
     let worker_api = Arc::new(rpc::get_proxy_api(cfg.url).await?);
     let resource: Arc<dyn resource::ResourceOp + Send + Sync> = match cfg.resource {
-        Resource::Db => Arc::new(RpcResource::new(worker_api.clone())),
+        Resource::RPC => Arc::new(RpcResource::new(worker_api.clone())),
         Resource::FS(path) => Arc::new(resource::FileResource::new(path)),
+        Resource::DB => return Err(anyhow!("db type in worker is deprecated, use rpc instead")),
     };
 
     let worker = worker::LocalWorker::new(

--- a/gpuproxy/src/gpuproxy_worker/main.rs
+++ b/gpuproxy/src/gpuproxy_worker/main.rs
@@ -29,7 +29,7 @@ const GPUPROXY_WORKER_ABOUT: &str = "gpuproxy worker";
 async fn main() {
     let worker_args = cli::get_worker_arg();
     let app_m = Command::new("gpuproxy-worker")
-        .version("0.0.1")
+        .version("0.0.2")
         .about(GPUPROXY_WORKER_ABOUT)
         .arg_required_else_help(true)
         .subcommand(

--- a/gpuproxy/src/proxy_rpc/db_ops.rs
+++ b/gpuproxy/src/proxy_rpc/db_ops.rs
@@ -38,6 +38,7 @@ pub trait ResourceRepo {
     async fn has_resource(&self, resource_id: String) -> Result<bool>;
     async fn get_resource_info(&self, resource_id: String) -> Result<Base64Byte>;
     async fn store_resource_info(&self, resource_id: String, resource: Vec<u8>) -> Result<String>;
+    async fn delete_resource(&self, resource_id: String) -> Result<()>;
 }
 
 #[async_trait]
@@ -435,6 +436,14 @@ impl ResourceRepo for DbOpsImpl {
             .insert(&self.conn)
             .await
             .map(|_| resource_id)
+            .anyhow()
+    }
+
+    async fn delete_resource(&self, resource_id: String) -> Result<()> {
+        ResourceInfos::Entity::delete_by_id(resource_id)
+            .exec(&self.conn)
+            .await
+            .map(|_| ())
             .anyhow()
     }
 }

--- a/gpuproxy/src/proxy_rpc/rpc.rs
+++ b/gpuproxy/src/proxy_rpc/rpc.rs
@@ -243,8 +243,13 @@ impl ProxyRpcServer for ProxyImpl {
         tid: String,
         proof: Base64Byte,
     ) -> RpcResult<()> {
+        let task = self.pool.fetch(tid.clone()).await.internal_call_error()?;
         self.pool
             .record_proof(worker_id_arg, tid, proof.0)
+            .await
+            .internal_call_error()?;
+        self.resource
+            .delete_resource(task.resource_id)
             .await
             .internal_call_error()
     }
@@ -376,6 +381,10 @@ impl ResourceRepo for WrapClient {
     }
 
     async fn store_resource_info(&self, resource_id: String, resource: Vec<u8>) -> Result<String> {
+        Err(anyhow!("not support store resource in rpc"))
+    }
+
+    async fn delete_resource(&self, resource_id: String) -> Result<()> {
         Err(anyhow!("not support store resource in rpc"))
     }
 }

--- a/gpuproxy/src/resource/mod.rs
+++ b/gpuproxy/src/resource/mod.rs
@@ -60,6 +60,12 @@ impl ResourceRepo for FileResource {
         fs::write(new_path, resource)?;
         Ok(resource_id)
     }
+
+    async fn delete_resource(&self, resource_id: String) -> Result<()> {
+        let new_path = Path::new(self.root.as_str()).join(resource_id.clone());
+        fs::remove_file(new_path)?;
+        Ok(())
+    }
 }
 
 /// Use database to persist task data
@@ -94,6 +100,10 @@ impl ResourceRepo for DbResource {
             .resource_repo
             .store_resource_info(resource_id, resource)
             .await;
+    }
+
+    async fn delete_resource(&self, resource_id: String) -> Result<()> {
+        return self.resource_repo.delete_resource(resource_id).await;
     }
 }
 


### PR DESCRIPTION
- correct “db” resource-type flag to "rpc"
- auto remove resource

close  https://github.com/ipfs-force-community/gpuproxy/issues/41
close https://github.com/ipfs-force-community/gpuproxy/issues/40